### PR TITLE
Migrations for extra columns to test various policy machine features

### DIFF
--- a/lib/test_app/db/migrate/20151106013525_add_tags_to_policy_element.rb
+++ b/lib/test_app/db/migrate/20151106013525_add_tags_to_policy_element.rb
@@ -1,0 +1,9 @@
+class AddTagsToPolicyElement < ActiveRecord::Migration
+  def change
+    if ActiveRecord::Base.connection.class.name == 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
+      add_column :policy_elements, :tags, 'text[]'
+    else
+      add_column :policy_elements, :tags, :text
+    end
+  end
+end

--- a/lib/test_app/db/migrate/201511061221759_add_color_to_policy_element.rb
+++ b/lib/test_app/db/migrate/201511061221759_add_color_to_policy_element.rb
@@ -1,0 +1,5 @@
+class AddColorToPolicyElement < ActiveRecord::Migration
+  def change
+    add_column :policy_elements, :color, :string
+  end
+end

--- a/lib/test_app/db/schema.rb
+++ b/lib/test_app/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151101013525) do
+ActiveRecord::Schema.define(version: 201511061221759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,8 @@ ActiveRecord::Schema.define(version: 20151101013525) do
     t.string "policy_machine_uuid"
     t.string "type",                null: false
     t.text   "extra_attributes"
+    t.text   "tags",                             array: true
+    t.string "color"
   end
 
   add_index "policy_elements", ["type"], name: "index_policy_elements_on_type", using: :btree


### PR DESCRIPTION
color is used to test extra attributes being added as database columns, and tags is used to test array columns (for postgres) and substring matching (for postgres or mysql).
